### PR TITLE
Fix MCP server API migration and improve logging

### DIFF
--- a/src/short-creator/libraries/FFmpeg.ts
+++ b/src/short-creator/libraries/FFmpeg.ts
@@ -6,7 +6,7 @@ export class FFMpeg {
   static async init(): Promise<FFMpeg> {
     return import("@ffmpeg-installer/ffmpeg").then((ffmpegInstaller) => {
       ffmpeg.setFfmpegPath(ffmpegInstaller.path);
-      logger.info("FFmpeg path set to:", ffmpegInstaller.path);
+      logger.info({ path: ffmpegInstaller.path }, "FFmpeg path set to");
       return new FFMpeg();
     });
   }

--- a/src/short-creator/libraries/Kokoro.ts
+++ b/src/short-creator/libraries/Kokoro.ts
@@ -58,7 +58,8 @@ export class Kokoro {
     header.writeUInt32LE(36 + totalDataLength, 4);
     header.writeUInt32LE(totalDataLength, 40);
 
-    return Buffer.concat([header, ...dataParts]);
+    const result = Buffer.concat([header, ...dataParts]);
+    return result.buffer.slice(result.byteOffset, result.byteOffset + result.byteLength);
   }
 
   static async init(dtype: kokoroModelPrecision): Promise<Kokoro> {


### PR DESCRIPTION
Hello! 

Amazing project you have here, I like it so much I got Gemini to make some changes so that it runs locally without error (mac).

I sorry this is a "works on my machine" type PR, but I think the fixes Gemini came up with are good.

## Changes

### 1. MCP Server API Migration (src/server/routers/mcp.ts)

The MCP SDK deprecated the `.tool()` API in favor of `.registerTool()`. This updates the code to use the new API format:

**Before:**
```typescript
this.mcpServer.tool(
  "get-video-status",
  "Get the status of a video...",
  { videoId: z.string().describe("...") },
  async ({ videoId }) => { ... }
);
```

**After:**
```typescript
this.mcpServer.registerTool(
  "get-video-status",
  {
    description: "Get the status of a video...",
    inputSchema: z.object({
      videoId: z.string().describe("..."),
    }) as any,
  },
  async (args: any) => {
    const { videoId } = args;
    // ...
  }
);
```

Key changes:
- Migrated from `.tool(name, description, schema, handler)` to `.registerTool(name, { description, inputSchema }, handler)`
- Updated schema format to use `z.object()` wrapper for inputSchema
- Added explicit type annotations (`as const`) for content types
- Removed deprecated `capabilities` object from McpServer constructor

**Impact:** Without this change, the MCP server will fail with newer SDK versions.

### 2. Kokoro ArrayBuffer Fix (src/short-creator/libraries/Kokoro.ts)

Fixed `concatWavBuffers()` to properly return an ArrayBuffer instead of a Node.js Buffer:

```typescript
// Before: returned Buffer (wrong type)
return Buffer.concat([header, ...dataParts]);

// After: properly extracts ArrayBuffer from Buffer
const result = Buffer.concat([header, ...dataParts]);
return result.buffer.slice(result.byteOffset, result.byteOffset + result.byteLength);
```

This ensures type consistency with the function signature and prevents potential issues with downstream ArrayBuffer consumers.

### 3. FFmpeg Structured Logging (src/short-creator/libraries/FFmpeg.ts)

Updated FFmpeg initialization logging to use Pino's structured format:

```typescript
// Before: string concatenation
logger.info("FFmpeg path set to:", ffmpegInstaller.path);

// After: structured logging
logger.info({ path: ffmpegInstaller.path }, "FFmpeg path set to");
```

This improves log parsing and consistency with the rest of the codebase's logging patterns.

## Compatibility

- **Non-breaking:** ArrayBuffer and logging changes are backward compatible
